### PR TITLE
Fix YubiKey detection when a user has multiple smartcard readers

### DIFF
--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -4,15 +4,17 @@ use yubikey_api::Context as YKContext;
 use crate::util::FidoDevice;
 
 pub fn get_yubikeys() -> Result<Vec<FidoDevice>> {
-    let mut readers =
+    let mut readers: YKContext =
         YKContext::open().with_context(|| "failed to create reader context for yubikeys")?;
     let mut output = Vec::<FidoDevice>::new();
 
     for reader in readers.iter()? {
-        let yubikey = reader
-            .open()
-            .with_context(|| format!("failed to open yubikey {}", reader.name()))?;
-        output.push(FidoDevice::YubiKey(yubikey))
+        if reader.name().as_ref().to_ascii_lowercase().contains(&"yubikey") {
+            let yubikey = reader
+                .open()
+                .with_context(|| format!("failed to open yubikey {}", reader.name()))?;
+            output.push(FidoDevice::YubiKey(yubikey))   
+        }
     }
 
     Ok(output)


### PR DESCRIPTION
I have a physical smartcard port installed on my laptop, and `gfh` naively assumed the first reader was the YubiKey. This PR implements proper detection to check if a reader is a YubiKey.